### PR TITLE
Add parsers for hr.dat and r.dat files

### DIFF
--- a/docs/src/api/util.md
+++ b/docs/src/api/util.md
@@ -31,5 +31,5 @@ Pages   = ["common/type.jl"]
 
 ```@autodocs
 Modules = [WannierIO]
-Pages   = ["util/header.jl", "util/toml.jl"]
+Pages   = ["util/header.jl", "util/toml.jl", "util/parser.jl"]
 ```

--- a/docs/src/api/w90.md
+++ b/docs/src/api/w90.md
@@ -29,6 +29,9 @@ Pages   = [
     "w90/nnkp.jl",
     "w90/chk.jl",
     "w90/tb.jl",
+    "w90/wsvec.jl",
+    "w90/hr.jl",
+    "w90/r.jl",
     "w90/hh_r.jl",
     "w90/band.jl",
 ]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,6 +26,9 @@ Output files:
 
 - `*_band.dat`
 - `*_tb.dat`
+- `*_wsvec.dat`
+- `*_hr.dat`
+- `*_r.dat`
 - `xsf`
 - `cube`
 - ...

--- a/src/WannierIO.jl
+++ b/src/WannierIO.jl
@@ -7,6 +7,7 @@ include("util/fortran.jl")
 include("util/lattice.jl")
 include("util/header.jl")
 include("util/toml.jl")
+include("util/parser.jl")
 
 using FortranFiles: FortranFile, FString, trimstring, Record
 
@@ -18,9 +19,12 @@ include("w90/mmn.jl")
 include("w90/eig.jl")
 include("w90/chk.jl")
 include("w90/unk.jl")
+include("w90/spn.jl")
 include("w90/band.jl")
 include("w90/tb.jl")
-include("w90/spn.jl")
+include("w90/wsvec.jl")
+include("w90/hr.jl")
+include("w90/r.jl")
 include("w90/hh_r.jl")
 
 # volumetric files

--- a/src/util/parser.jl
+++ b/src/util/parser.jl
@@ -1,0 +1,44 @@
+
+"""
+    $(SIGNATURES)
+
+Parse a vector of `n_elements` elements of type `T` from `io`.
+
+# Arguments
+- `io`: input stream
+- `T`: type of elements
+- `n_elements::Int`: total number of elements
+
+# Example
+
+Suppose a file `demo.txt` has the following content:
+```
+1  2  3  4  5  6  7  8  9  10
+11 12 13 14 15 16 17 18 19 20
+21 22 23
+```
+
+Then the following code parses the file and return a vector filled with 1 to 23:
+```julia-repl
+julia> vector = open("demo.txt") do io
+    parse_vector(io, Int, 23)
+end
+```
+
+The number of elements in each line can be different.
+"""
+function parse_vector(io::IO, T::Type, n_elements::Integer)
+    vec = zeros(T, n_elements)
+
+    counter = 0
+    while counter < n_elements
+        @assert !eof(io) "unexpected end of file"
+        line = strip(readline(io))
+        splitted = split(line)
+        n_splitted = length(splitted)
+        vec[(counter + 1):(counter + n_splitted)] = parse.(T, splitted)
+        counter += n_splitted
+    end
+
+    return vec
+end

--- a/src/w90/hr.jl
+++ b/src/w90/hr.jl
@@ -1,0 +1,38 @@
+export read_w90_hrdat
+
+"""
+    $(SIGNATURES)
+
+Read `prefix_hr.dat`.
+
+# Return
+- `Rvectors`: ``\\mathbf{R}``-vectors on which operators are defined
+- `Rdegens`: degeneracies of each ``\\mathbf{R}``-vector
+- `H`: Hamiltonian ``\\mathbf{H}(\\mathbf{R})``
+- `header`: the first line of the file
+"""
+function read_w90_hrdat(filename::AbstractString)
+    return open(filename) do io
+        header = strip(readline(io))
+        n_wann = parse(Int, strip(readline(io)))
+        n_Rvecs = parse(Int, strip(readline(io)))
+
+        Rdegens = parse_vector(io, Int, n_Rvecs)
+        Rvectors = zeros(Vec3{Int}, n_Rvecs)
+        H = [Matrix{ComplexF64}(undef, n_wann, n_wann) for _ in 1:n_Rvecs]
+        for iR in 1:n_Rvecs
+            for n in 1:n_wann
+                for m in 1:n_wann
+                    line = split(strip(readline(io)))
+                    Rvectors[iR] = parse.(Int, line[1:3])
+                    @assert m == parse(Int, line[4]) line
+                    @assert n == parse(Int, line[5]) line
+                    H[iR][m, n] = complex(parse(Float64, line[6]), parse(Float64, line[7]))
+                end
+            end
+        end
+
+        @info "Reading hr.dat file" filename header n_wann n_Rvecs
+        return (; Rvectors, Rdegens, H, header)
+    end
+end

--- a/src/w90/r.jl
+++ b/src/w90/r.jl
@@ -29,9 +29,15 @@ function read_w90_rdat(filename::AbstractString)
                     Rvectors[iR] = parse.(Int, line[1:3])
                     @assert m == parse(Int, line[4]) line
                     @assert n == parse(Int, line[5]) line
-                    r_x[iR][m, n] = complex(parse(Float64, line[6]), parse(Float64, line[7]))
-                    r_y[iR][m, n] = complex(parse(Float64, line[8]), parse(Float64, line[9]))
-                    r_z[iR][m, n] = complex(parse(Float64, line[10]), parse(Float64, line[11]))
+                    r_x[iR][m, n] = complex(
+                        parse(Float64, line[6]), parse(Float64, line[7])
+                    )
+                    r_y[iR][m, n] = complex(
+                        parse(Float64, line[8]), parse(Float64, line[9])
+                    )
+                    r_z[iR][m, n] = complex(
+                        parse(Float64, line[10]), parse(Float64, line[11])
+                    )
                 end
             end
         end

--- a/src/w90/r.jl
+++ b/src/w90/r.jl
@@ -1,0 +1,42 @@
+export read_w90_rdat
+
+"""
+    $(SIGNATURES)
+
+Read `prefix_r.dat`.
+
+# Return
+- `Rvectors`: ``\\mathbf{R}``-vectors on which operators are defined
+- `r_x`: ``x``-component of position operator
+- `r_y`: ``y``-component of position operator
+- `r_z`: ``z``-component of position operator
+- `header`: the first line of the file
+"""
+function read_w90_rdat(filename::AbstractString)
+    return open(filename) do io
+        header = strip(readline(io))
+        n_wann = parse(Int, strip(readline(io)))
+        n_Rvecs = parse(Int, strip(readline(io)))
+
+        Rvectors = zeros(Vec3{Int}, n_Rvecs)
+        r_x = [Matrix{ComplexF64}(undef, n_wann, n_wann) for _ in 1:n_Rvecs]
+        r_y = [Matrix{ComplexF64}(undef, n_wann, n_wann) for _ in 1:n_Rvecs]
+        r_z = [Matrix{ComplexF64}(undef, n_wann, n_wann) for _ in 1:n_Rvecs]
+        for iR in 1:n_Rvecs
+            for n in 1:n_wann
+                for m in 1:n_wann
+                    line = split(strip(readline(io)))
+                    Rvectors[iR] = parse.(Int, line[1:3])
+                    @assert m == parse(Int, line[4]) line
+                    @assert n == parse(Int, line[5]) line
+                    r_x[iR][m, n] = complex(parse(Float64, line[6]), parse(Float64, line[7]))
+                    r_y[iR][m, n] = complex(parse(Float64, line[8]), parse(Float64, line[9]))
+                    r_z[iR][m, n] = complex(parse(Float64, line[10]), parse(Float64, line[11]))
+                end
+            end
+        end
+
+        @info "Reading r.dat file" filename header n_wann n_Rvecs
+        return (; Rvectors, r_x, r_y, r_z, header)
+    end
+end

--- a/src/w90/wsvec.jl
+++ b/src/w90/wsvec.jl
@@ -1,0 +1,98 @@
+export read_w90_wsvec
+
+"""
+    $(SIGNATURES)
+
+Read `prefix_wsvec.dat`.
+
+# Return
+- `mdrs`: whether use MDRS interpolation, i.e. the `use_ws_distance` in the header
+- `Rvectors`: the ``\\mathbf{R}``-vectors
+- `Tvectors`: the ``\\mathbf{T}_{m n \\mathbf{R}}``-vectors.
+    Returned only `mdrs = true`.
+- `Tdegens`: the degeneracies of ``\\mathbf{T}_{m n \\mathbf{R}}``-vectors.
+    Returned only `mdrs = true`.
+- `header`: the first line of the file
+"""
+function read_w90_wsvec(filename::AbstractString)
+    header, mdrs, Rmn, Tvectors_flat, Tdegens_flat = open(filename) do io
+        header = strip(readline(io))
+
+        # check `use_ws_distance`
+        mdrs = false
+        mdrs_str = split(header)[end]
+        if occursin("use_ws_distance=", mdrs_str )
+            mdrs_str = lowercase(split(header, "use_ws_distance=")[2])
+            mdrs = parse_bool(mdrs_str)
+        end
+
+        Rmn = Vector{Vector{Int}}()
+        # Tvectors_flat[iRmn][iT] is Vec3 for T-vector, where iRmn is the index for the
+        # combination of Rvector and (m, n), iT is the index of T-vector at iRmn.
+        # Later on we will reorder this flattened vector, i.e., unfold the
+        # iRmn index into (iR, m, n).
+        Tvectors_flat = Vector{Vector{Vec3{Int}}}()
+        Tdegens_flat = Vector{Int}()
+
+        while !eof(io)
+            line = strip(readline(io))
+            # the last line is empty
+            if length(line) == 0
+                continue
+            end
+
+            Rx, Ry, Rz, m, n = parse.(Int, split(line))
+            push!(Rmn, [Rx, Ry, Rz, m, n])
+
+            n_T = parse(Int, strip(readline(io)))
+            push!(Tdegens_flat, n_T)
+
+            T = zeros(Vec3{Int}, n_T)
+            for iT in 1:n_T
+                line = strip(readline(io))
+                T[iT] = Vec3(parse.(Int, split(line))...)
+            end
+            push!(Tvectors_flat, T)
+        end
+
+        return header, mdrs, Rmn, Tvectors_flat, Tdegens_flat
+    end
+
+    # get number of WFs
+    n_wann = length(unique(i[end] for i in Rmn))
+    n_Rvecs = length(Rmn) ÷ n_wann^2
+
+    Rvectors = zeros(Vec3{Int}, n_Rvecs)
+    iR = 1
+    for rmn in Rmn
+        m, n = rmn[4:5]
+        if m == 1 && n == 1
+            Rvectors[iR] = Vec3(rmn[1:3])
+            iR += 1
+        end
+    end
+
+    if !mdrs
+        return (; mdrs, Rvectors, header)
+    end
+
+    # Objective: reorder Tvectors_flat -> Tvectors, Tdegens_flat -> Tdegens
+    # such that Tvectors[iR][m, n][iT] is Vec3 for T-vector
+    Tvectors = [Matrix{Vector{Vec3{Int}}}(undef, n_wann, n_wann) for _ in 1:n_Rvecs]
+    # and Tdegens[iR][m, n] is the degeneracy of T-vector at iR-th Rvector &
+    # between m-th and n-th WFs
+    Tdegens = [Matrix{Int}(undef, n_wann, n_wann) for _ in 1:n_Rvecs]
+    iR = 1
+    for (iRmn, rmn) in enumerate(Rmn)
+        m, n = rmn[(end - 1):end]
+        Tvectors[iR][m, n] = Tvectors_flat[iRmn]
+        Tdegens[iR][m, n] = Tdegens_flat[iRmn]
+        # next Rvector
+        if m == n_wann && n == n_wann
+            iR += 1
+        end
+    end
+
+    @info "Reading wsvec.dat file" filename header mdrs n_wann n_Rvecs
+    return (; mdrs, Rvectors, Tvectors, Tdegens, header)
+end

--- a/src/w90/wsvec.jl
+++ b/src/w90/wsvec.jl
@@ -21,7 +21,7 @@ function read_w90_wsvec(filename::AbstractString)
         # check `use_ws_distance`
         mdrs = false
         mdrs_str = split(header)[end]
-        if occursin("use_ws_distance=", mdrs_str )
+        if occursin("use_ws_distance=", mdrs_str)
             mdrs_str = lowercase(split(header, "use_ws_distance=")[2])
             mdrs = parse_bool(mdrs_str)
         end

--- a/test/util/parser.jl
+++ b/test/util/parser.jl
@@ -1,0 +1,16 @@
+@testitem "parse_vector" begin
+    io = IOBuffer("""1  2  3  4  5  6  7  8  9  10
+    11 12 13 14 15 16 17 18 19 20
+    21 22 23""")
+    vec = WannierIO.parse_vector(io, Int, 23)
+    @test vec == collect(1:23)
+    close(io)
+
+    # different number of elements per line
+    io = IOBuffer("""1  2  3  4  5
+    6
+    7 8 9""")
+    vec = WannierIO.parse_vector(io, Int, 9)
+    @test vec == collect(1:9)
+    close(io)
+end

--- a/test/w90/hr.jl
+++ b/test/w90/hr.jl
@@ -1,0 +1,27 @@
+@testitem "read hr ws" begin
+    using LazyArtifacts
+    hrdat = read_w90_hrdat(artifact"Si2_valence/reference/ws/Si2_valence_hr.dat")
+    # just some simple tests
+    @test length(hrdat.Rvectors) == 279
+    @test hrdat.Rvectors[1] == [-4, 0, 2]
+    @test length(hrdat.H) == 279
+    H1 = ComplexF64[
+        0.000805+0.0im -0.000431-0.0im -0.000137+0.0im -0.000431+0.0im
+        -0.000431-0.0im 0.000805+0.0im -0.000137+0.0im -0.000431-0.0im
+        -0.000299+0.0im -0.000298+0.0im 0.000534+0.0im -0.000298-0.0im
+        -0.000431+0.0im -0.000431+0.0im -0.000137-0.0im 0.000805-0.0im
+    ]
+    @test hrdat.H[1] ≈ H1
+end
+
+@testitem "read hr mdrs" begin
+    using LazyArtifacts
+    # The two files are identical
+    hrdat = read_w90_hrdat(artifact"Si2_valence/reference/ws/Si2_valence_hr.dat")
+    hrdat_ws = read_w90_hrdat(artifact"Si2_valence/reference/ws/Si2_valence_hr.dat")
+
+    for p in propertynames(hrdat)
+        p == :header && continue
+        @test hrdat_ws[p] ≈ hrdat[p]
+    end
+end

--- a/test/w90/r.jl
+++ b/test/w90/r.jl
@@ -1,0 +1,41 @@
+@testitem "read r ws" begin
+    using LazyArtifacts
+    rdat = read_w90_rdat(artifact"Si2_valence/reference/ws/Si2_valence_r.dat")
+    Rvectors1 = [-4, 0, 2]
+    @test rdat.Rvectors[1] == Rvectors1
+    r_x_end = ComplexF64[
+        0.0-0.0im -0.001846-0.0im 0.000296+0.0im 0.002093+0.0im
+        -0.000806-0.0im -0.0-0.0im -0.000149+0.0im -0.000806+0.0im
+        -4.4e-5-0.0im 0.00034+0.0im 0.0-0.0im -4.4e-5+0.0im
+        0.002093+0.0im -0.001846+0.0im 0.000296-0.0im -0.0-0.0im
+    ]
+    @test rdat.r_x[end] ≈ r_x_end
+
+    r_y_end = ComplexF64[
+        -0.0+0.0im -0.002093-0.0im -0.000296-0.0im 0.001846-0.0im
+        -0.002093+0.0im -0.0-0.0im -0.000296-0.0im 0.001846+0.0im
+        4.4e-5-0.0im 4.4e-5+0.0im -0.0+0.0im -0.00034+0.0im
+        0.000806+0.0im 0.000806+0.0im 0.000149+0.0im -0.0-0.0im
+    ]
+    @test rdat.r_y[end] ≈ r_y_end
+
+    r_z_end = ComplexF64[
+        0.0-0.0im -0.000806-0.0im -0.000149+0.0im -0.000806+0.0im
+        -0.001846-0.0im 0.0+0.0im 0.000296-0.0im 0.002093+0.0im
+        0.00034+0.0im -4.4e-5+0.0im 0.0-0.0im -4.4e-5-0.0im
+        -0.001846+0.0im 0.002093+0.0im 0.000296+0.0im -0.0+0.0im
+    ]
+    @test rdat.r_z[end] ≈ r_z_end
+end
+
+@testitem "read r mdrs" begin
+    using LazyArtifacts
+    # The two files are identical
+    rdat = read_w90_rdat(artifact"Si2_valence/reference/ws/Si2_valence_r.dat")
+    rdat_ws = read_w90_rdat(artifact"Si2_valence/reference/ws/Si2_valence_r.dat")
+
+    for p in propertynames(rdat)
+        p == :header && continue
+        @test rdat_ws[p] ≈ rdat[p]
+    end
+end

--- a/test/w90/tb.jl
+++ b/test/w90/tb.jl
@@ -1,32 +1,9 @@
-using WannierIO: Vec3
-@testitem "read wsvec ws" begin
-    using LazyArtifacts
-    mdrs, wsvec = read_w90_wsvec(artifact"Si2_valence/reference/ws/Si2_valence_wsvec.dat")
-
-    @assert mdrs == false
-    @test length(wsvec.R) == 279
-    @test wsvec.R[1] == [-4, 0, 2]
-end
-
-@testitem "read wsvec mdrs" begin
-    using WannierIO: Vec3
-    using LazyArtifacts
-    mdrs, wsvec = read_w90_wsvec(artifact"Si2_valence/reference/mdrs/Si2_valence_wsvec.dat")
-    @assert mdrs == true
-    @test length(wsvec.R) == 279
-    @test wsvec.R[1] == [-4, 0, 2]
-    @test length(wsvec.T) == 279
-    @test wsvec.T[1][1, 1] == Vector{Vec3}([[0, 0, 0], [6, 0, -6], [6, 0, 0]])
-    @test length(wsvec.Nᵀ) == 279
-    @test wsvec.Nᵀ[1] == [3 1 1 1; 1 3 1 1; 2 2 3 2; 1 1 1 3]
-end
-
 @testitem "read tb ws" begin
     using LazyArtifacts
     tbdat = read_w90_tbdat(artifact"Si2_valence/reference/ws/Si2_valence_tb.dat")
 
-    @test length(tbdat.R) == 279
-    @test tbdat.R[1] == [-4, 0, 2]
+    @test length(tbdat.Rvectors) == 279
+    @test tbdat.Rvectors[1] == [-4, 0, 2]
     @test length(tbdat.H) == 279
     H1 = ComplexF64[
         0.00080451304+1.6092791e-9im -0.00043090632-8.9535509e-9im -0.00013727432+1.7830477e-10im -0.00043090075+2.7695627e-9im
@@ -35,32 +12,32 @@ end
         -0.00043089878+6.7332791e-9im -0.00043091377+5.6168704e-9im -0.0001372618-4.1114441e-9im 0.00080451507-6.2301744e-9im
     ]
     @test tbdat.H[1] ≈ H1
-    @test length(tbdat.N) == 279
-    @test tbdat.N[1] == 3
+    @test length(tbdat.Rdegens) == 279
+    @test tbdat.Rdegens[1] == 3
     @test tbdat.lattice ==
         [0.0 2.715265 2.715265; 2.715265 0.0 2.715265; 2.715265 2.715265 0.0]
-    @test length(tbdat.rx) == length(tbdat.ry) == length(tbdat.rz) == 279
-    rx1 = ComplexF64[
+    @test length(tbdat.r_x) == length(tbdat.r_y) == length(tbdat.r_z) == 279
+    r_x1 = ComplexF64[
         3.6338163e-8+5.0525602e-8im -4.0150663e-5+1.506446e-8im 9.0607115e-5-5.4813038e-8im -0.0017405343-1.1882662e-8im
         0.0011077989+2.2693247e-8im -6.4595459e-9+5.4150924e-9im 0.00025422758-1.6273951e-8im 0.0011078169+2.8407141e-8im
         0.00012821382-2.969072e-8im 0.00013798637-2.1224108e-9im 5.4586044e-8+2.3435702e-8im 0.00012827449+8.9856419e-9im
         -0.0017405579-4.523964e-8im -4.007513e-5+3.8697593e-8im 9.0627952e-5+5.942338e-8im -1.6888038e-8+2.5373747e-9im
     ]
-    ry2 = ComplexF64[
+    r_y2 = ComplexF64[
         -2.5598094e-10-3.8026624e-9im 0.00074239939-1.8853816e-8im -0.00017865222+3.344151e-8im 0.00017582479+1.5301678e-8im
         0.00023456283+1.0709899e-8im -3.2666715e-8+4.7958915e-9im 0.00021987434-1.973943e-9im -1.3153397e-5+9.7076299e-9im
         1.319145e-5-1.4937437e-8im -0.00021977894+3.1806597e-9im -3.5269004e-8-1.3967952e-8im -0.00023454332+3.0129073e-8im
         -0.00017582461+1.1143559e-8im 0.00017861969+4.0119904e-8im -0.00074232978-1.8613896e-8im -2.2552721e-8-4.7774167e-9im
     ]
-    rz3 = ComplexF64[
+    r_z3 = ComplexF64[
         -2.7538102e-8-2.5754529e-9im 0.00017582603-4.8125766e-8im 0.00074233622-6.6380593e-9im -0.00017862626+1.7228737e-8im
         -0.00017585023-1.101898e-8im 6.7641871e-10-2.4185959e-8im 0.00017860646+3.7820915e-8im -0.00074235898-3.711759e-8im
         0.00023460039-2.0712049e-8im -1.318695e-5-4.598068e-9im 9.1295798e-9+4.1513854e-11im 0.00021978738+2.8018558e-8im
         1.3196588e-5+3.6553635e-9im -0.00023460902+3.2222708e-8im -0.00021979792-1.031378e-8im -3.1967074e-8-2.3895402e-8im
     ]
-    @test tbdat.rx[1] ≈ rx1
-    @test tbdat.ry[2] ≈ ry2
-    @test tbdat.rz[3] ≈ rz3
+    @test tbdat.r_x[1] ≈ r_x1
+    @test tbdat.r_y[2] ≈ r_y2
+    @test tbdat.r_z[3] ≈ r_z3
 end
 
 @testitem "read tb mdrs" begin
@@ -70,6 +47,7 @@ end
     tbdat_ws = read_w90_tbdat(artifact"Si2_valence/reference/ws/Si2_valence_tb.dat")
 
     for p in propertynames(tbdat)
+        p == :header && continue
         @test tbdat_ws[p] ≈ tbdat[p]
     end
 end

--- a/test/w90/wsvec.jl
+++ b/test/w90/wsvec.jl
@@ -1,0 +1,22 @@
+@testitem "read wsvec ws" begin
+    using LazyArtifacts
+    wsvec = read_w90_wsvec(artifact"Si2_valence/reference/ws/Si2_valence_wsvec.dat")
+
+    @assert wsvec.mdrs == false
+    @test length(wsvec.Rvectors) == 279
+    @test wsvec.Rvectors[1] == [-4, 0, 2]
+end
+
+@testitem "read wsvec mdrs" begin
+    using WannierIO: Vec3
+    using LazyArtifacts
+    wsvec = read_w90_wsvec(artifact"Si2_valence/reference/mdrs/Si2_valence_wsvec.dat")
+
+    @assert wsvec.mdrs == true
+    @test length(wsvec.Rvectors) == 279
+    @test wsvec.Rvectors[1] == [-4, 0, 2]
+    @test length(wsvec.Tvectors) == 279
+    @test wsvec.Tvectors[1][1, 1] == Vector{Vec3}([[0, 0, 0], [6, 0, -6], [6, 0, 0]])
+    @test length(wsvec.Tdegens) == 279
+    @test wsvec.Tdegens[1] == [3 1 1 1; 1 3 1 1; 2 2 3 2; 1 1 1 3]
+end


### PR DESCRIPTION
I noticed parsers are missing for these two file formats that are part of the regular Wannier90 output, so I added them. To finish, I think an example `r.dat` file is needed and a test should be written (I drafted one as a comment). Having these additional parsers would be very useful since I could start using WannierIO.jl in AutoBZ.jl