### PR TITLE
Fix variable scope for julia 1.10

### DIFF
--- a/src/w90/nnkp.jl
+++ b/src/w90/nnkp.jl
@@ -127,14 +127,11 @@ function read_nnkp(filename::AbstractString, ::Wannier90Toml)
 end
 
 function read_nnkp(filename::AbstractString)
+    format = Wannier90Text()
     try
         TOML.parsefile(filename)
     catch err
-        if err isa TOML.ParserError
-            format = Wannier90Text()
-        else
-            rethrow()
-        end
+        err isa TOML.ParserError || rethrow()
     else
         format = Wannier90Toml()
     end

--- a/src/w90/win.jl
+++ b/src/w90/win.jl
@@ -316,14 +316,11 @@ function read_win(filename::AbstractString, ::Wannier90Toml; fix_inputs::Bool=tr
 end
 
 function read_win(filename::AbstractString; fix_inputs=true)
+    format = Wannier90Text()
     try
         TOML.parsefile(filename)
     catch err
-        if err isa TOML.ParserError
-            format = Wannier90Text()
-        else
-            rethrow()
-        end
+        err isa TOML.ParserError || rethrow()
     else
         format = Wannier90Toml()
     end


### PR DESCRIPTION
It seems in julia 1.10, the variable needs to be first declared outside of the `try`/`if` block, otherwise it complains

```julia
ERROR: LoadError: UndefVarError: `format` not defined
Stacktrace:
  [1] read_win(filename::String; fix_inputs::Bool)
    @ WannierIO ~/work/WannierIO.jl/WannierIO.jl/src/w90/win.jl:330
  [2] read_win(filename::String)
    @ WannierIO ~/work/WannierIO.jl/WannierIO.jl/src/w90/win.jl:318
  [3] top-level scope
    @ /opt/hostedtoolcache/julia/1.10.0/x64/share/julia/stdlib/v1.10/Artifacts/src/Artifacts.jl:698
  [4] eval
    @ Core ./boot.jl:385 [inlined]
  [5] include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)
    @ Base ./loading.jl:2070
  [6] include_string(m::Module, txt::String, fname::String)
    @ Base ./loading.jl:2080
  [7] #invokelatest#2
    @ ./essentials.jl:887 [inlined]
  [8] invokelatest
    @ ./essentials.jl:884 [inlined]
  [9] #3
    @ ~/.julia/packages/TestItemRunner/XLYqa/src/TestItemRunner.jl:102 [inlined]
 [10] withpath(f::TestItemRunner.var"#3#4"{String, String, Module}, path::String)
    @ TestItemRunner ~/.julia/packages/TestItemRunner/XLYqa/src/vendored_code.jl:7
 [11] run_testitem(filepath::String, use_default_usings::Bool, setups::Vector{Symbol}, package_name::String, original_code::String, line::Int64, column::Int64, test_setup_module_set::TestItemRunner.TestSetupModuleSet)
    @ TestItemRunner ~/.julia/packages/TestItemRunner/XLYqa/src/TestItemRunner.jl:101
 [12] run_tests(path::String; filter::Nothing, verbose::Bool)
    @ TestItemRunner ~/.julia/packages/TestItemRunner/XLYqa/src/TestItemRunner.jl:185
 [13] top-level scope
    @ ~/work/WannierIO.jl/WannierIO.jl/test/runtests.jl:10
 [14] include(fname::String)
    @ Base.MainInclude ./client.jl:489
 [15] top-level scope
    @ none:6
in expression starting at /home/runner/work/WannierIO.jl/WannierIO.jl/test/w90/chk.jl:40
in expression starting at /home/runner/work/WannierIO.jl/WannierIO.jl/test/runtests.jl:10
ERROR: LoadError: Package WannierIO errored during testing
```